### PR TITLE
set max connections to unlimited and make the session timeout longer to get rid of exceeded max connections of 30 error

### DIFF
--- a/hbase-site.xml
+++ b/hbase-site.xml
@@ -11,4 +11,12 @@
     <name>hbase.zookeeper.quorum</name>
     <value>dev.banno.com</value>
   </property>
+  <property>
+     <name>hbase.zookeeper.property.maxClientCnxns</name>
+     <value>0</value>
+  </property>
+  <property>
+    <name>zookeeper.session.timeout</name>
+    <value>1200000</value>
+  </property>
 </configuration>


### PR DESCRIPTION
Fixing this message:

`org.apache.hadoop.hbase.ZooKeeperConnectionException: HBase is able to connect to ZooKeeper but the connection closes immediately. This could be a sign that the server has too many connections (30 is the default). Consider inspecting your ZK server logs for that error and then make sure you are reusing HBaseConfiguration as often as you can. See HTable's javadoc for more information.`

